### PR TITLE
Implement agent-scoped volatile knowledge upload functionality

### DIFF
--- a/src/SerenityStar/Agents/Conversational/Conversation.cs
+++ b/src/SerenityStar/Agents/Conversational/Conversation.cs
@@ -52,7 +52,7 @@ namespace SerenityStar.Agents.Conversational
             _agentCode = agentCode;
             _version = version;
             _options = options;
-            VolatileKnowledge = new ConversationVolatileKnowledgeScope(httpClient);
+            VolatileKnowledge = new ConversationVolatileKnowledgeScope(httpClient, agentCode);
         }
 
         /// <summary>

--- a/src/SerenityStar/Agents/System/AIProxiesScope.cs
+++ b/src/SerenityStar/Agents/System/AIProxiesScope.cs
@@ -35,7 +35,7 @@ namespace SerenityStar.Agents.System
             : base(httpClient, agentCode, options)
         {
             _proxyOptions = options;
-            VolatileKnowledge = new ConversationVolatileKnowledgeScope(httpClient);
+            VolatileKnowledge = new ConversationVolatileKnowledgeScope(httpClient, agentCode);
         }
 
         /// <inheritdoc/>

--- a/src/SerenityStar/Agents/System/ActivitiesScope.cs
+++ b/src/SerenityStar/Agents/System/ActivitiesScope.cs
@@ -35,7 +35,7 @@ namespace SerenityStar.Agents.System
         public Activity(HttpClient httpClient, string agentCode, int? version = null, AgentExecutionReq? options = null)
             : base(httpClient, agentCode, version, options)
         {
-            VolatileKnowledge = new ConversationVolatileKnowledgeScope(httpClient);
+            VolatileKnowledge = new ConversationVolatileKnowledgeScope(httpClient, agentCode);
         }
 
         /// <inheritdoc/>

--- a/src/SerenityStar/Agents/System/ChatCompletionsScope.cs
+++ b/src/SerenityStar/Agents/System/ChatCompletionsScope.cs
@@ -41,7 +41,7 @@ namespace SerenityStar.Agents.System
         {
             _chatOptions = options;
             _version = version;
-            VolatileKnowledge = new ConversationVolatileKnowledgeScope(httpClient);
+            VolatileKnowledge = new ConversationVolatileKnowledgeScope(httpClient, agentCode);
         }
 
         /// <inheritdoc/>

--- a/src/SerenityStar/Agents/VolatileKnowledge/ConversationVolatileKnowledgeScope.cs
+++ b/src/SerenityStar/Agents/VolatileKnowledge/ConversationVolatileKnowledgeScope.cs
@@ -18,11 +18,13 @@ namespace SerenityStar.Agents.VolatileKnowledge
     public sealed class ConversationVolatileKnowledgeScope
     {
         private readonly HttpClient _httpClient;
+        private readonly string _agentCode;
         private readonly List<Guid> _knowledgeIds;
 
-        internal ConversationVolatileKnowledgeScope(HttpClient httpClient)
+        internal ConversationVolatileKnowledgeScope(HttpClient httpClient, string agentCode)
         {
             _httpClient = httpClient;
+            _agentCode = agentCode;
             _knowledgeIds = new List<Guid>();
         }
 
@@ -35,6 +37,11 @@ namespace SerenityStar.Agents.VolatileKnowledge
         /// Uploads a file or content as volatile knowledge and associates it with the current conversation/activity.
         /// The knowledge will be automatically included in the next message sent.
         /// </summary>
+        /// <remarks>
+        /// This uses the subtenant-scoped endpoint and does not validate the file type against an agent's
+        /// configuration. To validate the file type against the agent's allowed MIME types at upload time,
+        /// use <see cref="UploadForAgentAsync"/>.
+        /// </remarks>
         /// <param name="request">The upload request containing file stream or content</param>
         /// <param name="processEmbeddings">Optional parameter to indicate whether to process embeddings. Default is true.</param>
         /// <param name="noExpiration">Optional parameter to indicate whether the knowledge should not expire. Default is false.</param>
@@ -50,59 +57,134 @@ namespace SerenityStar.Agents.VolatileKnowledge
         {
             request.Validate();
 
-            using (MultipartFormDataContent content = new())
+            using (MultipartFormDataContent content = BuildMultipartContent(request))
             {
-                // Add content if provided
-                if (!string.IsNullOrEmpty(request.Content))
-                    content.Add(new StringContent(request.Content), "Content");
+                string endpoint = $"/api/v2/volatileknowledge?{BuildQueryString(processEmbeddings, noExpiration, expirationDays)}";
 
-                // Add file if provided
-                if (request.FileStream is not null)
-                {
-                    StreamContent fileContent = new(request.FileStream);
-                    string contentType = GetContentType(request.FileName);
-                    fileContent.Headers.ContentType = new MediaTypeHeaderValue(contentType);
-                    content.Add(fileContent, "File", request.FileName);
-                }
+                HttpResponseMessage response = await _httpClient.PostAsync(endpoint, content, cancellationToken);
 
-                // Add callback URL if provided
-                if (!string.IsNullOrEmpty(request.CallbackUrl))
-                    content.Add(new StringContent(request.CallbackUrl), "CallbackUrl");
-
-                // Build query parameters
-                List<string> queryParams = new List<string>
-                {
-                    $"processEmbeddings={processEmbeddings}",
-                    $"noExpiration={noExpiration}"
-                };
-
-                if (expirationDays.HasValue)
-                    queryParams.Add($"expirationDays={expirationDays.Value}");
-
-                string queryString = string.Join("&", queryParams);
-                string endpoint = $"/api/v2/volatileknowledge?{queryString}";
-
-                HttpResponseMessage response = await _httpClient.PostAsync(
-                    endpoint,
-                    content,
-                    cancellationToken);
-
-                if (!response.IsSuccessStatusCode)
-                {
-                    string errorContent = await response.Content.ReadAsStringAsync();
-                    throw new HttpRequestException($"Request failed with status code {response.StatusCode}: {errorContent}");
-                }
-
-                VolatileKnowledgeRes? volatileKnowledge = await response.Content.ReadFromJsonAsync<VolatileKnowledgeRes>(JsonSerializerOptionsCache.s_camelCase, cancellationToken: cancellationToken);
-
-                if (volatileKnowledge is null)
-                    throw new InvalidOperationException("Failed to deserialize volatile knowledge response");
-
-                // Add to the list of knowledge IDs for automatic association
-                _knowledgeIds.Add(volatileKnowledge.Id);
-
-                return volatileKnowledge;
+                return await HandleUploadResponseAsync(response, cancellationToken);
             }
+        }
+
+        /// <summary>
+        /// Uploads a file or content as volatile knowledge scoped to this agent and associates it with the
+        /// current conversation/activity. The file type is validated against the agent's configured allowed
+        /// MIME types at upload time.
+        /// </summary>
+        /// <param name="request">The upload request containing file stream or content</param>
+        /// <param name="processEmbeddings">Optional parameter to indicate whether to process embeddings. Default is true.</param>
+        /// <param name="noExpiration">Optional parameter to indicate whether the knowledge should not expire. Default is false.</param>
+        /// <param name="expirationDays">Optional parameter to specify the number of days until expiration.</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>The created volatile knowledge entity, associated with the agent.</returns>
+        public async Task<VolatileKnowledgeRes> UploadForAgentAsync(
+            UploadVolatileKnowledgeReq request,
+            bool processEmbeddings = true,
+            bool noExpiration = false,
+            int? expirationDays = null,
+            CancellationToken cancellationToken = default)
+        {
+            request.Validate();
+
+            using (MultipartFormDataContent content = BuildMultipartContent(request))
+            {
+                string endpoint = $"/api/agent/{_agentCode}/volatileKnowledge?{BuildQueryString(processEmbeddings, noExpiration, expirationDays)}";
+
+                HttpResponseMessage response = await _httpClient.PostAsync(endpoint, content, cancellationToken);
+
+                return await HandleUploadResponseAsync(response, cancellationToken);
+            }
+        }
+
+        /// <summary>
+        /// Uploads volatile knowledge from an existing file ID, scoped to this agent.
+        /// The file type is validated against the agent's configured allowed MIME types at upload time.
+        /// </summary>
+        /// <param name="request">The upload request containing the file ID and options.</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>The created volatile knowledge entity, associated with the agent.</returns>
+        public async Task<VolatileKnowledgeRes> UploadFromFileForAgentAsync(
+            UploadVolatileKnowledgeFromFileReq request,
+            CancellationToken cancellationToken = default)
+        {
+            request.Validate();
+
+            HttpResponseMessage response = await _httpClient.PostAsJsonAsync(
+                $"/api/agent/{_agentCode}/volatileKnowledge/upload/file",
+                request,
+                JsonSerializerOptionsCache.s_camelCase,
+                cancellationToken);
+
+            return await HandleUploadResponseAsync(response, cancellationToken);
+        }
+
+        /// <summary>
+        /// Uploads volatile knowledge from a URL, scoped to this agent.
+        /// The file type is validated against the agent's configured allowed MIME types at upload time.
+        /// </summary>
+        /// <param name="request">The upload request containing the file URL and options.</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>The created volatile knowledge entity, associated with the agent.</returns>
+        public async Task<VolatileKnowledgeRes> UploadFromUrlForAgentAsync(
+            UploadVolatileKnowledgeFromUrlReq request,
+            CancellationToken cancellationToken = default)
+        {
+            request.Validate();
+
+            HttpResponseMessage response = await _httpClient.PostAsJsonAsync(
+                $"/api/agent/{_agentCode}/volatileKnowledge/upload/url",
+                request,
+                JsonSerializerOptionsCache.s_camelCase,
+                cancellationToken);
+
+            return await HandleUploadResponseAsync(response, cancellationToken);
+        }
+
+        /// <summary>
+        /// Uploads volatile knowledge from a base64-encoded file, scoped to this agent.
+        /// The file type is validated against the agent's configured allowed MIME types at upload time.
+        /// </summary>
+        /// <param name="request">The upload request containing the base64 content and options.</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>The created volatile knowledge entity, associated with the agent.</returns>
+        public async Task<VolatileKnowledgeRes> UploadFromBase64ForAgentAsync(
+            UploadVolatileKnowledgeFromBase64Req request,
+            CancellationToken cancellationToken = default)
+        {
+            request.Validate();
+
+            HttpResponseMessage response = await _httpClient.PostAsJsonAsync(
+                $"/api/agent/{_agentCode}/volatileKnowledge/upload/base64",
+                request,
+                JsonSerializerOptionsCache.s_camelCase,
+                cancellationToken);
+
+            return await HandleUploadResponseAsync(response, cancellationToken);
+        }
+
+        /// <summary>
+        /// Gets the MIME types allowed for volatile knowledge uploads to this agent.
+        /// If the agent has no configured types, all platform-supported types are returned.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The list of allowed MIME types.</returns>
+        public async Task<IReadOnlyList<string>> GetAllowedMimeTypesAsync(
+            CancellationToken cancellationToken = default)
+        {
+            HttpResponseMessage response = await _httpClient.GetAsync(
+                $"/api/agent/{_agentCode}/volatileKnowledge/mimeTypes",
+                cancellationToken);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                string errorContent = await response.Content.ReadAsStringAsync();
+                throw new HttpRequestException($"Request failed with status code {response.StatusCode}: {errorContent}");
+            }
+
+            List<string>? mimeTypes = await response.Content.ReadFromJsonAsync<List<string>>(JsonSerializerOptionsCache.s_camelCase, cancellationToken: cancellationToken);
+
+            return mimeTypes ?? throw new InvalidOperationException("Failed to deserialize allowed MIME types response");
         }
 
         /// <summary>
@@ -125,7 +207,7 @@ namespace SerenityStar.Agents.VolatileKnowledge
                 throw new HttpRequestException($"Request failed with status code {response.StatusCode}: {errorContent}");
             }
 
-            VolatileKnowledgeRes? volatileKnowledge = await response.Content.ReadFromJsonAsync<VolatileKnowledgeRes>(cancellationToken: cancellationToken);
+            VolatileKnowledgeRes? volatileKnowledge = await response.Content.ReadFromJsonAsync<VolatileKnowledgeRes>(JsonSerializerOptionsCache.s_camelCase, cancellationToken: cancellationToken);
 
             return volatileKnowledge ?? throw new InvalidOperationException("Failed to deserialize volatile knowledge response");
         }
@@ -140,6 +222,64 @@ namespace SerenityStar.Agents.VolatileKnowledge
         }
 
         #region Private Methods
+
+        private MultipartFormDataContent BuildMultipartContent(UploadVolatileKnowledgeReq request)
+        {
+            MultipartFormDataContent content = new();
+
+            // Add content if provided
+            if (!string.IsNullOrEmpty(request.Content))
+                content.Add(new StringContent(request.Content), "Content");
+
+            // Add file if provided
+            if (request.FileStream is not null)
+            {
+                StreamContent fileContent = new(request.FileStream);
+                string contentType = GetContentType(request.FileName);
+                fileContent.Headers.ContentType = new MediaTypeHeaderValue(contentType);
+                content.Add(fileContent, "File", request.FileName);
+            }
+
+            // Add callback URL if provided
+            if (!string.IsNullOrEmpty(request.CallbackUrl))
+                content.Add(new StringContent(request.CallbackUrl), "CallbackUrl");
+
+            return content;
+        }
+
+        private static string BuildQueryString(bool processEmbeddings, bool noExpiration, int? expirationDays)
+        {
+            List<string> queryParams = new List<string>
+            {
+                $"processEmbeddings={processEmbeddings}",
+                $"noExpiration={noExpiration}"
+            };
+
+            if (expirationDays.HasValue)
+                queryParams.Add($"expirationDays={expirationDays.Value}");
+
+            return string.Join("&", queryParams);
+        }
+
+        private async Task<VolatileKnowledgeRes> HandleUploadResponseAsync(HttpResponseMessage response, CancellationToken cancellationToken)
+        {
+            if (!response.IsSuccessStatusCode)
+            {
+                string errorContent = await response.Content.ReadAsStringAsync();
+                throw new HttpRequestException($"Request failed with status code {response.StatusCode}: {errorContent}");
+            }
+
+            VolatileKnowledgeRes? volatileKnowledge = await response.Content.ReadFromJsonAsync<VolatileKnowledgeRes>(JsonSerializerOptionsCache.s_camelCase, cancellationToken: cancellationToken);
+
+            if (volatileKnowledge is null)
+                throw new InvalidOperationException("Failed to deserialize volatile knowledge response");
+
+            // Add to the list of knowledge IDs for automatic association
+            _knowledgeIds.Add(volatileKnowledge.Id);
+
+            return volatileKnowledge;
+        }
+
         private static string GetContentType(string fileName)
         {
             string extension = Path.GetExtension(fileName).ToLowerInvariant();
@@ -154,7 +294,9 @@ namespace SerenityStar.Agents.VolatileKnowledge
                 ".jpg" => "image/jpg",
                 ".jpeg" => "image/jpeg",
                 ".png" => "image/png",
-                _ => throw new NotSupportedException($"File extension '{extension}' is not supported for upload."),
+                // Fall back to a generic content type for unknown extensions; the backend validates
+                // the actual allowed types (globally and per-agent) at upload time.
+                _ => "application/octet-stream",
             };
         }
         #endregion

--- a/src/SerenityStar/Models/VolatileKnowledge/UploadVolatileKnowledgeFromBase64Req.cs
+++ b/src/SerenityStar/Models/VolatileKnowledge/UploadVolatileKnowledgeFromBase64Req.cs
@@ -1,0 +1,61 @@
+using System;
+
+namespace SerenityStar.Models.VolatileKnowledge
+{
+    /// <summary>
+    /// Represents a request to upload volatile knowledge from a base64-encoded file.
+    /// </summary>
+    public sealed class UploadVolatileKnowledgeFromBase64Req
+    {
+        /// <summary>
+        /// Gets or sets the name of the file being uploaded, including its extension.
+        /// </summary>
+        public string FileName { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the MIME type of the file (e.g. "application/pdf", "text/plain").
+        /// </summary>
+        public string MimeType { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the base64-encoded content of the file.
+        /// </summary>
+        public string ContentBase64 { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the callback URL to be notified when processing is complete.
+        /// </summary>
+        public string? CallbackUrl { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the knowledge should not expire. Default is false.
+        /// </summary>
+        public bool NoExpiration { get; set; }
+
+        /// <summary>
+        /// Gets or sets the number of days until expiration.
+        /// If not provided, the default expiration days from system configuration will be used.
+        /// </summary>
+        public int? ExpirationDays { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to process embeddings. Default is false.
+        /// </summary>
+        public bool ProcessEmbeddings { get; set; }
+
+        /// <summary>
+        /// Validates that the required values are provided.
+        /// </summary>
+        public void Validate()
+        {
+            if (string.IsNullOrEmpty(FileName))
+                throw new ArgumentException("FileName is required.");
+
+            if (string.IsNullOrEmpty(MimeType))
+                throw new ArgumentException("MimeType is required.");
+
+            if (string.IsNullOrEmpty(ContentBase64))
+                throw new ArgumentException("ContentBase64 is required.");
+        }
+    }
+}

--- a/src/SerenityStar/Models/VolatileKnowledge/UploadVolatileKnowledgeFromFileReq.cs
+++ b/src/SerenityStar/Models/VolatileKnowledge/UploadVolatileKnowledgeFromFileReq.cs
@@ -1,0 +1,45 @@
+using System;
+
+namespace SerenityStar.Models.VolatileKnowledge
+{
+    /// <summary>
+    /// Represents a request to upload volatile knowledge from an existing file ID.
+    /// </summary>
+    public sealed class UploadVolatileKnowledgeFromFileReq
+    {
+        /// <summary>
+        /// Gets or sets the ID of the file to upload as volatile knowledge.
+        /// </summary>
+        public Guid FileId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the callback URL to be notified when processing is complete.
+        /// </summary>
+        public string? CallbackUrl { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the knowledge should not expire. Default is false.
+        /// </summary>
+        public bool NoExpiration { get; set; }
+
+        /// <summary>
+        /// Gets or sets the number of days until expiration.
+        /// If not provided, the default expiration days from system configuration will be used.
+        /// </summary>
+        public int? ExpirationDays { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to process embeddings. Default is false.
+        /// </summary>
+        public bool ProcessEmbeddings { get; set; }
+
+        /// <summary>
+        /// Validates that the required values are provided.
+        /// </summary>
+        public void Validate()
+        {
+            if (FileId == Guid.Empty)
+                throw new ArgumentException("FileId is required.");
+        }
+    }
+}

--- a/src/SerenityStar/Models/VolatileKnowledge/UploadVolatileKnowledgeFromUrlReq.cs
+++ b/src/SerenityStar/Models/VolatileKnowledge/UploadVolatileKnowledgeFromUrlReq.cs
@@ -1,0 +1,48 @@
+namespace SerenityStar.Models.VolatileKnowledge
+{
+    /// <summary>
+    /// Represents a request to upload volatile knowledge from a URL.
+    /// </summary>
+    public sealed class UploadVolatileKnowledgeFromUrlReq
+    {
+        /// <summary>
+        /// Gets or sets the URL from which to download and upload the file.
+        /// </summary>
+        public string FileUrl { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the file name. If not provided, it will be extracted from the URL.
+        /// </summary>
+        public string? FileName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the callback URL to be notified when processing is complete.
+        /// </summary>
+        public string? CallbackUrl { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the knowledge should not expire. Default is false.
+        /// </summary>
+        public bool NoExpiration { get; set; }
+
+        /// <summary>
+        /// Gets or sets the number of days until expiration.
+        /// If not provided, the default expiration days from system configuration will be used.
+        /// </summary>
+        public int? ExpirationDays { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to process embeddings. Default is false.
+        /// </summary>
+        public bool ProcessEmbeddings { get; set; }
+
+        /// <summary>
+        /// Validates that the required values are provided.
+        /// </summary>
+        public void Validate()
+        {
+            if (string.IsNullOrEmpty(FileUrl))
+                throw new System.ArgumentException("FileUrl is required.");
+        }
+    }
+}

--- a/src/SerenityStar/Models/VolatileKnowledge/VolatileKnowledgeRes.cs
+++ b/src/SerenityStar/Models/VolatileKnowledge/VolatileKnowledgeRes.cs
@@ -37,5 +37,15 @@ namespace SerenityStar.Models.VolatileKnowledge
         /// Gets or sets the file ID associated with the uploaded file.
         /// </summary>
         public Guid? FileId { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether embeddings have been generated for this knowledge.
+        /// </summary>
+        public bool EmbeddingsGenerated { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the content has been scanned.
+        /// </summary>
+        public bool Scanned { get; set; }
     }
 }

--- a/tests/SerenityStar.IntegrationTests/AgentVolatileKnowledgeTests.cs
+++ b/tests/SerenityStar.IntegrationTests/AgentVolatileKnowledgeTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using SerenityStar.Agents.Conversational;
 using SerenityStar.Client;
+using SerenityStar.Models.Execute;
 using SerenityStar.Models.VolatileKnowledge;
 using Xunit;
 
@@ -160,6 +161,50 @@ public class AgentVolatileKnowledgeTests : IClassFixture<TestFixture>
             () => conversation.VolatileKnowledge.UploadForAgentAsync(request));
 
         Assert.Contains("400", ex.Message);
+    }
+
+    [Fact]
+    public async Task ExecuteAgent_WithAgentUploadedKnowledge_ShouldUseUploadedDocument()
+    {
+        // Arrange - upload knowledge through the agent-scoped endpoint
+        EnsureTestFileExists();
+        Conversation conversation = _client.Agents.Assistants.CreateConversation(_fixture.AssistantAgent);
+
+        using FileStream fileStream = File.OpenRead(_testFilePath);
+        UploadVolatileKnowledgeReq uploadRequest = new()
+        {
+            FileStream = fileStream,
+            FileName = TestFileName
+        };
+
+        VolatileKnowledgeRes uploaded = await conversation.VolatileKnowledge.UploadForAgentAsync(uploadRequest);
+        Guid knowledgeId = uploaded.Id;
+
+        // Wait for processing to complete
+        VolatileKnowledgeRes status = uploaded;
+        int maxAttempts = 30;
+        int attempts = 0;
+        while (status.Status != VolatileKnowledgeSimpleStatus.Invalid
+            && status.Status != VolatileKnowledgeSimpleStatus.Error
+            && status.Status != VolatileKnowledgeSimpleStatus.Success
+            && attempts < maxAttempts)
+        {
+            await Task.Delay(1000);
+            status = await conversation.VolatileKnowledge.GetStatusAsync(knowledgeId);
+            attempts++;
+        }
+
+        Assert.Equal(VolatileKnowledgeSimpleStatus.Success, status.Status);
+
+        // Act - the agent-uploaded knowledge is automatically associated with the next message
+        AgentResult result = await conversation.SendMessageAsync(
+            "Según el documento adjunto, ¿en qué año se levantó el sitio de Orléans? Responde solo con el año.");
+
+        // Assert - the answer (1429) only appears in the uploaded document
+        Assert.NotNull(result);
+        Assert.NotEmpty(result.Content);
+        Assert.Contains("1429", result.Content);
+        Assert.NotNull(conversation.ConversationId);
     }
 
     [Fact]

--- a/tests/SerenityStar.IntegrationTests/AgentVolatileKnowledgeTests.cs
+++ b/tests/SerenityStar.IntegrationTests/AgentVolatileKnowledgeTests.cs
@@ -1,0 +1,181 @@
+using Microsoft.Extensions.DependencyInjection;
+using SerenityStar.Agents.Conversational;
+using SerenityStar.Client;
+using SerenityStar.Models.VolatileKnowledge;
+using Xunit;
+
+namespace SerenityStar.IntegrationTests;
+
+/// <summary>
+/// Integration tests for the agent-scoped volatile knowledge upload endpoints
+/// (POST /api/agent/{agentCode}/volatileKnowledge and its variants).
+/// </summary>
+public class AgentVolatileKnowledgeTests : IClassFixture<TestFixture>
+{
+    private const string TestFileName = "test-document.txt";
+
+    private readonly TestFixture _fixture;
+    private readonly ISerenityClient _client;
+    private readonly string _testFilePath;
+
+    public AgentVolatileKnowledgeTests(TestFixture fixture)
+    {
+        _fixture = fixture;
+        _client = _fixture.ServiceProvider.GetRequiredService<ISerenityClient>();
+        string baseDirectory = AppContext.BaseDirectory;
+        string projectRoot = Path.GetFullPath(Path.Combine(baseDirectory, "..", "..", ".."));
+        _testFilePath = Path.Combine(projectRoot, TestFileName);
+    }
+
+    private void EnsureTestFileExists()
+    {
+        if (!File.Exists(_testFilePath))
+            throw new FileNotFoundException($"Test file not found at {_testFilePath}");
+    }
+
+    [Fact]
+    public async Task UploadForAgent_WithValidFile_ShouldAssociateAgentId()
+    {
+        // Arrange
+        EnsureTestFileExists();
+        Conversation conversation = _client.Agents.Assistants.CreateConversation(_fixture.AssistantAgent);
+
+        using FileStream fileStream = File.OpenRead(_testFilePath);
+        UploadVolatileKnowledgeReq request = new()
+        {
+            FileStream = fileStream,
+            FileName = TestFileName
+        };
+
+        // Act
+        VolatileKnowledgeRes result = await conversation.VolatileKnowledge.UploadForAgentAsync(request);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.NotEqual(Guid.Empty, result.Id);
+        Assert.NotNull(result.Status);
+    }
+
+    [Fact]
+    public async Task UploadForAgent_WithContent_ShouldSucceed()
+    {
+        // Arrange
+        Conversation conversation = _client.Agents.Assistants.CreateConversation(_fixture.AssistantAgent);
+        UploadVolatileKnowledgeReq request = new()
+        {
+            Content = "https://serenitystar.ai"
+        };
+
+        // Act
+        VolatileKnowledgeRes result = await conversation.VolatileKnowledge.UploadForAgentAsync(request);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.NotEqual(Guid.Empty, result.Id);
+    }
+
+    [Fact]
+    public async Task UploadFromBase64ForAgent_WithValidContent_ShouldSucceed()
+    {
+        // Arrange
+        Conversation conversation = _client.Agents.Assistants.CreateConversation(_fixture.AssistantAgent);
+        byte[] bytes = System.Text.Encoding.UTF8.GetBytes("Sample volatile knowledge content for base64 upload.");
+        UploadVolatileKnowledgeFromBase64Req request = new()
+        {
+            FileName = "base64-document.txt",
+            MimeType = "text/plain",
+            ContentBase64 = Convert.ToBase64String(bytes)
+        };
+
+        // Act
+        VolatileKnowledgeRes result = await conversation.VolatileKnowledge.UploadFromBase64ForAgentAsync(request);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.NotEqual(Guid.Empty, result.Id);
+    }
+
+    [Fact]
+    public async Task UploadFromFileForAgent_WithExistingFileId_ShouldSucceed()
+    {
+        // Arrange - first upload a file to obtain a file id
+        EnsureTestFileExists();
+        Conversation conversation = _client.Agents.Assistants.CreateConversation(_fixture.AssistantAgent);
+
+        Guid fileId;
+        using (FileStream fileStream = File.OpenRead(_testFilePath))
+        {
+            UploadVolatileKnowledgeReq seedRequest = new()
+            {
+                FileStream = fileStream,
+                FileName = TestFileName
+            };
+            VolatileKnowledgeRes seed = await conversation.VolatileKnowledge.UploadForAgentAsync(seedRequest);
+            Assert.True(seed.FileId.HasValue, "Expected a file id from the seed upload.");
+            fileId = seed.FileId!.Value;
+        }
+
+        UploadVolatileKnowledgeFromFileReq request = new()
+        {
+            FileId = fileId
+        };
+
+        // Act
+        VolatileKnowledgeRes result = await conversation.VolatileKnowledge.UploadFromFileForAgentAsync(request);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.NotEqual(Guid.Empty, result.Id);
+    }
+
+    [Fact]
+    public async Task GetAllowedMimeTypes_ShouldReturnNonEmptyList()
+    {
+        // Arrange
+        Conversation conversation = _client.Agents.Assistants.CreateConversation(_fixture.AssistantAgent);
+
+        // Act
+        IReadOnlyList<string> mimeTypes = await conversation.VolatileKnowledge.GetAllowedMimeTypesAsync();
+
+        // Assert
+        Assert.NotNull(mimeTypes);
+        Assert.NotEmpty(mimeTypes);
+    }
+
+    [Fact]
+    public async Task UploadForAgent_WithUnsupportedFileType_ShouldThrowWithBackendError()
+    {
+        // Arrange
+        Conversation conversation = _client.Agents.Assistants.CreateConversation(_fixture.AssistantAgent);
+        byte[] bytes = { 0x00, 0x01, 0x02, 0x03 };
+        using MemoryStream stream = new(bytes);
+        UploadVolatileKnowledgeReq request = new()
+        {
+            FileStream = stream,
+            FileName = "malicious.exe"
+        };
+
+        // Act & Assert - the backend rejects unsupported types with a 400 that the SDK surfaces.
+        HttpRequestException ex = await Assert.ThrowsAsync<HttpRequestException>(
+            () => conversation.VolatileKnowledge.UploadForAgentAsync(request));
+
+        Assert.Contains("400", ex.Message);
+    }
+
+    [Fact]
+    public async Task UploadForAgent_WithInvalidAgentCode_ShouldThrowNotFound()
+    {
+        // Arrange
+        Conversation conversation = _client.Agents.Assistants.CreateConversation("non-existent-agent-code-xyz");
+        UploadVolatileKnowledgeReq request = new()
+        {
+            Content = "https://serenitystar.ai"
+        };
+
+        // Act & Assert
+        HttpRequestException ex = await Assert.ThrowsAsync<HttpRequestException>(
+            () => conversation.VolatileKnowledge.UploadForAgentAsync(request));
+
+        Assert.Contains("404", ex.Message);
+    }
+}

--- a/tests/SerenityStar.IntegrationTests/TestFixture.cs
+++ b/tests/SerenityStar.IntegrationTests/TestFixture.cs
@@ -49,7 +49,8 @@ public class TestFixture : IDisposable
                 "No valid API key found. Please set 'SerenityStar:ApiKey' in appsettings.Development.json or environment variables. " +
                 "Integration tests require a valid Serenity Star API key to run.");
 
-        services.AddSerenityStar(apiKey!);
+        string? baseUrl = Configuration["SerenityStar:BaseUrl"];
+        services.AddSerenityStar(apiKey!, baseUrl: baseUrl);
 
         ServiceProvider = services.BuildServiceProvider();
     }


### PR DESCRIPTION
# Update .NET SDK for Agent-Scoped Volatile Knowledge Uploads

Adds SDK support for the new agent-scoped Volatile Knowledge upload endpoints. This enables .NET integrations to use the new upload flow with per-agent file-type validation without requiring custom HTTP calls.

## New Methods

Available on `ConversationVolatileKnowledgeScope` (via `.VolatileKnowledge` on `Activity`, `ChatCompletion`, `Proxy`, and `Conversation`):

### Upload Methods

| Method | Endpoint |
|----------|----------|
| `UploadForAgentAsync` | `POST /api/agent/{agentCode}/volatileKnowledge` |
| `UploadFromFileForAgentAsync` | `POST .../upload/file` |
| `UploadFromUrlForAgentAsync` | `POST .../upload/url` |
| `UploadFromBase64ForAgentAsync` | `POST .../upload/base64` |

### MIME Type Discovery

| Method | Endpoint |
|----------|----------|
| `GetAllowedMimeTypesAsync` | `GET .../mimeTypes` |

## Other Changes

### New Request Models

- `UploadVolatileKnowledgeFromFileReq`
- `UploadVolatileKnowledgeFromUrlReq`
- `UploadVolatileKnowledgeFromBase64Req`

### Response Model Updates

`VolatileKnowledgeRes` now includes:

- `EmbeddingsGenerated`
- `Scanned`

These additions align the SDK response model with the backend DTO.

### Backward Compatibility

The legacy global upload endpoint remains unchanged:

```text
/api/v2/volatileknowledge
```

### New tests
<img width="896" height="278" alt="image" src="https://github.com/user-attachments/assets/bc36080a-53aa-4845-99f9-5723ca64d167" />